### PR TITLE
Fix: 1D perturbation integration crash due to scalar/array mismatch

### DIFF
--- a/scripts/LinearResponseExperiments_OneDimensionalMap.py
+++ b/scripts/LinearResponseExperiments_OneDimensionalMap.py
@@ -19,10 +19,10 @@ def print_memory(label=""):
 
 
 def uniform_pert(point: np.ndarray):
-    return np.array([1])
+    return 1.0
 
 
-def single_response_uniform_pertubation(xi, eps, avg_obs, base_map, seed):
+def single_response_uniform_pertubation(xi, eps, avg_obs, base_map, seed=None):
     try:
         perturbed_map = one_dim_map()
         perturbed_map.M = base_map.M

--- a/src/KoopmanismResponse/dynamical_systems/Models.py
+++ b/src/KoopmanismResponse/dynamical_systems/Models.py
@@ -54,13 +54,23 @@ class one_dim_map:
                 "Initial condition `x0` has not been set. Call `set_random_initial_condition()` first."
             )
 
-        xold = self.x0
+        xold_arr = np.asarray(self.x0).squeeze()
+        if xold_arr.ndim != 0:
+            raise ValueError(
+                f"Initial condition `x0` must be scalar-like, got shape {np.shape(self.x0)}"
+            )
+        xold = float(xold_arr)
         tsave = np.arange(0, self.M)
         x = np.zeros(len(tsave))
 
         for idx, t in enumerate(tqdm(tsave, disable=not show_progress)):
-            xnew = self._drift(t=t, x=xold)
-            xold = xnew.copy()
+            xnew_arr = np.asarray(self._drift(t=t, x=xold)).squeeze()
+            if xnew_arr.ndim != 0:
+                raise ValueError(
+                    f"Drift returned non-scalar state at step {idx}: shape {np.shape(xnew_arr)}"
+                )
+            xnew = float(xnew_arr)
+            xold = xnew
             x[idx] = xnew
 
         t = tsave[self.transient :]


### PR DESCRIPTION
### Description
This PR fixes an intermittent crash in the one-dimensional response experiment where perturbed runs failed with:

"setting an array element with a sequence"

### Cause
The issue was caused by inconsistent handling of scalar vs array values in the 1D perturbation integration.

### What changed
- In `scripts/LinearResponseExperiments_OneDimensionalMap.py`, the perturbation direction now returns a scalar (`1.0`) instead of a 1-element array.
- In `src/KoopmanismResponse/dynamical_systems/Models.py`, the one-dimensional integrator now:
  - Normalizes scalar-like `x0` and drift outputs safely
  - Raises a clear `ValueError` if a non-scalar state is passed or produced

### Fix
Ensure consistent scalar/array handling so that assignments always match expected shapes.

### Notes
- Only affects 1D case
- No changes to higher-dimensional behavior